### PR TITLE
add a llvm-ar step before link optimisation

### DIFF
--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -37,9 +37,11 @@ LOCALOBJS += utils/probes.o
 endif
 endif
 
-OBJS = \
+ONLYOBJS = \
 	$(LOCALOBJS) \
-	$(SUBDIROBJS) \
+	$(SUBDIROBJS)
+OBJS = \
+	$(ONLYOBJS) \
 	$(top_builddir)/src/common/libpgcommon_srv.a \
 	$(top_builddir)/src/port/libpgport_srv.a
 
@@ -60,15 +62,27 @@ override LDFLAGS := $(LDFLAGS) $(LDFLAGS_EX) $(LDFLAGS_EX_BE)
 
 all: submake-libpgport submake-catalog-headers submake-utils-headers postgres $(POSTGRES_IMP)
 
+ifneq ($(PORTNAME), emscripten)
 ifneq ($(PORTNAME), cygwin)
 ifneq ($(PORTNAME), win32)
 ifneq ($(PORTNAME), aix)
 
 postgres: $(OBJS)
-	$(CC) $(MAIN_MODULE) $(CFLAGS) $(call expand_subsys,$^) $(LDFLAGS) $(LIBS) -o $@
+	$(CC) $(CFLAGS) $(call expand_subsys,$^) $(LDFLAGS) $(LIBS) -o $@
 
 endif
 endif
+endif
+endif
+
+ifeq ($(PORTNAME), emscripten)
+PGLITE += $(top_builddir)/libpglite.a
+PGLITE += $(top_builddir)/src/common/libpgcommon_srv.a
+PGLITE += $(top_builddir)/src/port/libpgport_srv.a
+PGMAIN = main/main.o tcop/postgres.o
+postgres: $(OBJS)
+	$(AR) cr ../../libpglite.a $(filter-out $(PGMAIN),$(call expand_subsys,$(ONLYOBJS)))
+	COPTS="-Oz -g0 --closure 1" $(CC) $(MAIN_MODULE) $(CFLAGS) $(LDFLAGS) -o $@ $(PGMAIN) $(PGLITE) $(LIBS)
 endif
 
 ifeq ($(PORTNAME), cygwin)


### PR DESCRIPTION
goal: keep libplite.a static with all debug

speed up link/optimisation pass by re using the same static lib