### PR TITLE
Update PGlite docker builder image

### DIFF
--- a/wasm-build/build-with-docker.sh
+++ b/wasm-build/build-with-docker.sh
@@ -5,7 +5,7 @@
 # we are using a custom emsdk to build pglite wasm
 # this is available as a docker image under electricsql/pglite-builder
 IMG_NAME="electricsql/pglite-builder"
-IMG_TAG="17.4_3.1.61.6bi"
+IMG_TAG="17.4_3.1.61.7bi"
 
 [ -f ./pglite/.buildconfig ] && cp ./pglite/.buildconfig .buildconfig
 


### PR DESCRIPTION
The previous docker image did not properly support arm64 hosts.