### PR TITLE
Move DEBUG env out of .buildconfig

### DIFF
--- a/.buildconfig
+++ b/.buildconfig
@@ -7,7 +7,6 @@ SDKROOT=/tmp/sdk
 
 PG_DIST=/tmp/sdk/dist
 PG_DIST_EXT=/tmp/sdk/dist/extensions-emsdk
-DEBUG=false
 CI=true
 
 GETZIC=false

--- a/wasm-build/build-with-docker.sh
+++ b/wasm-build/build-with-docker.sh
@@ -35,6 +35,7 @@ fi
 docker run $@ \
   --rm \
   --env-file .buildconfig \
+  -e DEBUG=${DEBUG:-false} \
   --workdir=${DOCKER_WORKSPACE} \
   -v ${WORKSPACE}/postgres-pglite:${DOCKER_WORKSPACE}:rw \
   -v ${WORKSPACE}/postgres-pglite/dist:/tmp/sdk/dist:rw \


### PR DESCRIPTION
Allow scripts to set the `DEBUG` env var dynamically such that it is straightforward to build a `pglite` debug version.